### PR TITLE
Move currentKeyboardScript into SettingsValues and simplify InputLogic methods

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardActionListenerImpl.kt
@@ -91,7 +91,6 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
             inputLogic.onCodeInput(
                 settings.current, event,
                 keyboardSwitcher.getKeyboardShiftMode(), // TODO: this is not necessarily correct for a hardware keyboard right now
-                keyboardSwitcher.getCurrentKeyboardScript(),
                 latinIME.mHandler
             )
             return true
@@ -337,7 +336,7 @@ class KeyboardActionListenerImpl(private val latinIME: LatinIME, private val inp
         inputLogic.finishInput()
         val newPosition = connection.expectedSelectionStart + moveSteps
         connection.setSelection(newPosition, newPosition)
-        inputLogic.restartSuggestionsOnWordTouchedByCursor(settings.current, keyboardSwitcher.currentKeyboardScript)
+        inputLogic.restartSuggestionsOnWordTouchedByCursor(settings.current)
         return true
     }
 

--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -112,7 +112,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         if (themeUpdated) {
             Settings settings = Settings.getInstance();
             settings.loadSettings(displayContext, settings.getCurrent().mLocale,
-                    settings.getCurrent().mInputAttributes);
+                    settings.getCurrent().mInputAttributes, settings.getCurrent().mCurrentKeyboardScript);
             if (mKeyboardView != null)
                 mLatinIME.setInputView(onCreateInputView(displayContext, mIsHardwareAcceleratedDrawingEnabled));
         }
@@ -759,7 +759,7 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         if (mThemeNeedsReload) // necessary in some cases (e.g. theme switch) when mThemeNeedsReload is set
                                // before first keyboard load
             Settings.getInstance().loadSettings(displayContext, Settings.getValues().mLocale,
-                    Settings.getValues().mInputAttributes);
+                    Settings.getValues().mInputAttributes, Settings.getValues().mCurrentKeyboardScript);
 
         updateKeyboardThemeAndContextThemeWrapper(displayContext, KeyboardTheme.getKeyboardTheme(displayContext));
         mCurrentInputView = (InputView) LayoutInflater.from(mThemeContext).inflate(R.layout.input_view, null);

--- a/app/src/main/java/helium314/keyboard/latin/KeyboardWrapperView.kt
+++ b/app/src/main/java/helium314/keyboard/latin/KeyboardWrapperView.kt
@@ -87,7 +87,7 @@ class KeyboardWrapperView @JvmOverloads constructor(
                     // Force reload settings synchronously to ensure the new scale is used immediately
                     val settings = Settings.getInstance()
                     val values = Settings.getValues()
-                    settings.loadSettings(context, values.mLocale, values.mInputAttributes)
+                    settings.loadSettings(context, values.mLocale, values.mInputAttributes, values.mCurrentKeyboardScript)
                     KeyboardSwitcher.getInstance().setOneHandedModeEnabled(true, true)
                 }
                 else -> x = 0f

--- a/app/src/main/java/helium314/keyboard/latin/LatinIME.java
+++ b/app/src/main/java/helium314/keyboard/latin/LatinIME.java
@@ -256,8 +256,7 @@ public class LatinIME extends InputMethodService implements
                     break;
                 case MSG_RESUME_SUGGESTIONS:
                     latinIme.mInputLogic.restartSuggestionsOnWordTouchedByCursor(
-                            latinIme.mSettings.getCurrent(),
-                            latinIme.mKeyboardSwitcher.getCurrentKeyboardScript());
+                            latinIme.mSettings.getCurrent());
                     break;
                 case MSG_REOPEN_DICTIONARIES:
                     // We need to re-evaluate the currently composing word in case the script has
@@ -593,7 +592,8 @@ public class LatinIME extends InputMethodService implements
         final EditorInfo editorInfo = getCurrentInputEditorInfo();
         final InputAttributes inputAttributes = new InputAttributes(
                 editorInfo, isFullscreenMode(), getPackageName());
-        mSettings.loadSettings(this, locale, inputAttributes);
+        final String currentKeyboardScript = mKeyboardSwitcher.getCurrentKeyboardScript();
+        mSettings.loadSettings(this, locale, inputAttributes, currentKeyboardScript);
         final SettingsValues currentSettingsValues = mSettings.getCurrent();
         AudioAndHapticFeedbackManager.getInstance().onSettingsChanged(currentSettingsValues);
         // This method is called on startup and language switch, before the new layout
@@ -1515,8 +1515,7 @@ public class LatinIME extends InputMethodService implements
             mRichImm.switchToShortcutIme(this);
         }
         final InputTransaction completeInputTransaction = mInputLogic.onCodeInput(mSettings.getCurrent(), event,
-                mKeyboardSwitcher.getKeyboardShiftMode(),
-                mKeyboardSwitcher.getCurrentKeyboardScript(), mHandler);
+                mKeyboardSwitcher.getKeyboardShiftMode(), mHandler);
         updateStateAfterInputTransaction(completeInputTransaction);
         mKeyboardSwitcher.onEvent(event, getCurrentAutoCapsState(), getCurrentRecapitalizeState());
     }
@@ -1527,8 +1526,7 @@ public class LatinIME extends InputMethodService implements
         final InputTransaction completeInputTransaction = mInputLogic.onTextInput(mSettings.getCurrent(), event,
                 mKeyboardSwitcher.getKeyboardShiftMode(), mHandler);
         updateStateAfterInputTransaction(completeInputTransaction);
-        mInputLogic.restartSuggestionsOnWordTouchedByCursor(mSettings.getCurrent(),
-                mKeyboardSwitcher.getCurrentKeyboardScript());
+        mInputLogic.restartSuggestionsOnWordTouchedByCursor(mSettings.getCurrent());
         mKeyboardSwitcher.onEvent(event, getCurrentAutoCapsState(), getCurrentRecapitalizeState());
     }
 
@@ -1694,7 +1692,6 @@ public class LatinIME extends InputMethodService implements
         final InputTransaction completeInputTransaction = mInputLogic.onPickSuggestionManually(
                 mSettings.getCurrent(), suggestionInfo,
                 mKeyboardSwitcher.getKeyboardShiftMode(),
-                mKeyboardSwitcher.getCurrentKeyboardScript(),
                 mHandler);
         updateStateAfterInputTransaction(completeInputTransaction);
 

--- a/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
+++ b/app/src/main/java/helium314/keyboard/latin/inputlogic/InputLogic.java
@@ -305,7 +305,8 @@ public final class InputLogic {
     // interface
     public InputTransaction onPickSuggestionManually(final SettingsValues settingsValues,
             final SuggestedWordInfo suggestionInfo, final int keyboardShiftState,
-            final String currentKeyboardScript, final LatinIME.UIHandler handler) {
+            final LatinIME.UIHandler handler) {
+        final String currentKeyboardScript = settingsValues.mCurrentKeyboardScript;
         if (isInlineEmojiSearchAction()) {
             deleteTextReplacedByEmoji();
         }
@@ -321,7 +322,7 @@ public final class InputLogic {
             // Rely on onCodeInput to do the complicated swapping/stripping logic
             // consistently.
             final Event event = Event.createPunctuationSuggestionPickedEvent(suggestionInfo);
-            return onCodeInput(settingsValues, event, keyboardShiftState, currentKeyboardScript, handler);
+            return onCodeInput(settingsValues, event, keyboardShiftState, handler);
         }
 
         final Event event = Event.createSuggestionPickedEvent(suggestionInfo);
@@ -509,7 +510,8 @@ public final class InputLogic {
      */
     public InputTransaction onCodeInput(final SettingsValues settingsValues,
             @NonNull final Event event, final int keyboardShiftMode,
-            final String currentKeyboardScript, final LatinIME.UIHandler handler) {
+            final LatinIME.UIHandler handler) {
+        final String currentKeyboardScript = settingsValues.mCurrentKeyboardScript;
         mWordBeingCorrectedByCursor = null;
         mJustRevertedACommit = false;
         final Event processedEvent = mWordComposer.processEvent(event);
@@ -540,7 +542,7 @@ public final class InputLogic {
             if (currentEvent.isConsumed()) {
                 handleConsumedEvent(currentEvent, inputTransaction);
             } else if (currentEvent.isFunctionalKeyEvent()) {
-                handleFunctionalEvent(currentEvent, inputTransaction, currentKeyboardScript, handler);
+                handleFunctionalEvent(currentEvent, inputTransaction, handler);
             } else {
                 handleNonFunctionalEvent(currentEvent, inputTransaction, handler);
             }
@@ -552,7 +554,7 @@ public final class InputLogic {
         if (!mConnection.hasSlowInputConnection() && !mWordComposer.isComposingWord()
                 && (settingsValues.isWordCodePoint(processedEvent.getCodePoint())
                         || processedEvent.getKeyCode() == KeyCode.DELETE)) {
-            mWordBeingCorrectedByCursor = getWordAtCursor(settingsValues, currentKeyboardScript);
+            mWordBeingCorrectedByCursor = getWordAtCursor(settingsValues);
         }
         if (!inputTransaction.didAutoCorrect() && processedEvent.getKeyCode() != KeyCode.SHIFT
                 && processedEvent.getKeyCode() != KeyCode.CAPS_LOCK
@@ -940,11 +942,12 @@ public final class InputLogic {
      * @param inputTransaction The transaction in progress.
      */
     private void handleFunctionalEvent(final Event event, final InputTransaction inputTransaction,
-            final String currentKeyboardScript, final LatinIME.UIHandler handler) {
+            final LatinIME.UIHandler handler) {
+        final String currentKeyboardScript = inputTransaction.getSettingsValues().mCurrentKeyboardScript;
         final int keyCode = event.getKeyCode();
         switch (keyCode) {
             case KeyCode.DELETE:
-                handleBackspaceEvent(event, inputTransaction, currentKeyboardScript);
+                handleBackspaceEvent(event, inputTransaction);
                 // Backspace is a functional key, but it affects the contents of the editor.
                 inputTransaction.setDidAffectContents();
                 break;
@@ -1021,7 +1024,7 @@ public final class InputLogic {
                     // fake delete keypress to remove the text
                     final Event backspaceEvent = Event.createSoftwareKeypressEvent(KeyCode.DELETE, 0,
                             event.getX(), event.getY(), event.isKeyRepeat());
-                    handleBackspaceEvent(backspaceEvent, inputTransaction, currentKeyboardScript);
+                    handleBackspaceEvent(backspaceEvent, inputTransaction);
                     inputTransaction.setDidAffectContents();
                 }
                 break;
@@ -1595,8 +1598,8 @@ public final class InputLogic {
      * @param event            The event to handle.
      * @param inputTransaction The transaction in progress.
      */
-    private void handleBackspaceEvent(final Event event, final InputTransaction inputTransaction,
-            final String currentKeyboardScript) {
+    private void handleBackspaceEvent(final Event event, final InputTransaction inputTransaction) {
+        final String currentKeyboardScript = inputTransaction.getSettingsValues().mCurrentKeyboardScript;
         mSpaceState = SpaceState.NONE;
         mDeleteCount++;
 
@@ -1668,8 +1671,7 @@ public final class InputLogic {
                 // (non-revert) backspace handling.
                 if (inputTransaction.getSettingsValues().needsToLookupSuggestions()
                         && inputTransaction.getSettingsValues().mSpacingAndPunctuations.mCurrentLanguageHasSpaces) {
-                    restartSuggestionsOnWordTouchedByCursor(inputTransaction.getSettingsValues(),
-                            currentKeyboardScript);
+                    restartSuggestionsOnWordTouchedByCursor(inputTransaction.getSettingsValues());
                 }
                 return;
             }
@@ -1754,7 +1756,7 @@ public final class InputLogic {
                         // consider unlearning here because we may have already reached
                         // the previous word, and will lose it after next deletion.
                         hasUnlearnedWordBeingDeleted |= unlearnWordBeingDeleted(
-                                inputTransaction.getSettingsValues(), currentKeyboardScript);
+                                inputTransaction.getSettingsValues());
                         sendDownUpKeyEvent(KeyEvent.KEYCODE_DEL);
                         totalDeletedLength++;
                     }
@@ -1791,7 +1793,7 @@ public final class InputLogic {
                         // consider unlearning here because we may have already reached
                         // the previous word, and will lose it after next deletion.
                         hasUnlearnedWordBeingDeleted |= unlearnWordBeingDeleted(
-                                inputTransaction.getSettingsValues(), currentKeyboardScript);
+                                inputTransaction.getSettingsValues());
                         final int codePointBeforeCursorToDeleteAgain = mConnection.getCodePointBeforeCursor();
                         if (codePointBeforeCursorToDeleteAgain != Constants.NOT_A_CODE) {
                             final int lengthToDeleteAgain = codePointBeforeCursor > 0xFE00
@@ -1807,19 +1809,19 @@ public final class InputLogic {
             }
             if (!hasUnlearnedWordBeingDeleted) {
                 // Consider unlearning the word being deleted (if we have not done so already).
-                unlearnWordBeingDeleted(
-                        inputTransaction.getSettingsValues(), currentKeyboardScript);
+                unlearnWordBeingDeleted(inputTransaction.getSettingsValues());
             }
             if (mConnection.hasSlowInputConnection()) {
                 mSuggestionStripViewAccessor.setNeutralSuggestionStrip();
             } else if (inputTransaction.getSettingsValues().needsToLookupSuggestions()
                     && inputTransaction.getSettingsValues().mSpacingAndPunctuations.mCurrentLanguageHasSpaces) {
-                restartSuggestionsOnWordTouchedByCursor(inputTransaction.getSettingsValues(), currentKeyboardScript);
+                restartSuggestionsOnWordTouchedByCursor(inputTransaction.getSettingsValues());
             }
         }
     }
 
-    String getWordAtCursor(final SettingsValues settingsValues, final String currentKeyboardScript) {
+    String getWordAtCursor(final SettingsValues settingsValues) {
+        final String currentKeyboardScript = settingsValues.mCurrentKeyboardScript;
         if (!mConnection.hasSelection()
                 && settingsValues.needsToLookupSuggestions()
                 && settingsValues.mSpacingAndPunctuations.mCurrentLanguageHasSpaces) {
@@ -1832,8 +1834,8 @@ public final class InputLogic {
         return "";
     }
 
-    boolean unlearnWordBeingDeleted(
-            final SettingsValues settingsValues, final String currentKeyboardScript) {
+    boolean unlearnWordBeingDeleted(final SettingsValues settingsValues) {
+        final String currentKeyboardScript = settingsValues.mCurrentKeyboardScript;
         if (mConnection.hasSlowInputConnection()) {
             // TODO: Refactor unlearning so that it does not incur any extra calls
             // to the InputConnection. That way it can still be performed on a slow
@@ -1845,7 +1847,7 @@ public final class InputLogic {
         // entered the composing state yet), unlearn the word.
         // TODO: Consider tracking whether or not this word was typed by the user.
         if (!mConnection.isCursorFollowedByWordCharacter(settingsValues.mSpacingAndPunctuations)) {
-            final String wordBeingDeleted = getWordAtCursor(settingsValues, currentKeyboardScript);
+            final String wordBeingDeleted = getWordAtCursor(settingsValues);
             if (!TextUtils.isEmpty(wordBeingDeleted)) {
                 unlearnWord(wordBeingDeleted, settingsValues, Constants.EVENT_BACKSPACE);
                 return true;
@@ -2186,9 +2188,8 @@ public final class InputLogic {
      *
      * @param settingsValues the current values of the settings.
      */
-    public void restartSuggestionsOnWordTouchedByCursor(final SettingsValues settingsValues,
-            // TODO: remove this argument, put it into settingsValues
-            final String currentKeyboardScript) {
+    public void restartSuggestionsOnWordTouchedByCursor(final SettingsValues settingsValues) {
+        final String currentKeyboardScript = settingsValues.mCurrentKeyboardScript;
         // HACK: We may want to special-case some apps that exhibit bad behavior in case
         // of
         // recorrection. This is a temporary, stopgap measure that will be removed

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -37,6 +37,7 @@ import helium314.keyboard.latin.utils.LayoutType;
 import helium314.keyboard.latin.utils.Log;
 import helium314.keyboard.latin.utils.ResourceUtils;
 import helium314.keyboard.latin.utils.RunInLocaleKt;
+import helium314.keyboard.latin.utils.ScriptUtils;
 import helium314.keyboard.latin.utils.StatsUtils;
 import helium314.keyboard.latin.utils.SubtypeSettings;
 import helium314.keyboard.latin.utils.ToolbarKey;
@@ -276,7 +277,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
                 return;
             }
             ToolbarUtilsKt.clearCustomToolbarKeyCodes();
-            loadSettings(mContext, mSettingsValues.mLocale, mSettingsValues.mInputAttributes);
+            loadSettings(mContext, mSettingsValues.mLocale, mSettingsValues.mInputAttributes, mSettingsValues.mCurrentKeyboardScript);
             StatsUtils.onLoadSettings(mSettingsValues);
         } finally {
             mSettingsValuesLock.unlock();
@@ -295,18 +296,18 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
             return;
         final Locale locale = ConfigurationCompatKt.locale(context.getResources().getConfiguration());
         final InputAttributes inputAttributes = new InputAttributes(new EditorInfo(), false, context.getPackageName());
-        loadSettings(context, locale, inputAttributes);
+        loadSettings(context, locale, inputAttributes, ScriptUtils.SCRIPT_UNKNOWN);
     }
 
     public void loadSettings(final Context context, final Locale locale,
-            @NonNull final InputAttributes inputAttributes) {
+            @NonNull final InputAttributes inputAttributes, final String currentKeyboardScript) {
         mSettingsValuesLock.lock();
         mContext = context;
         try {
             final SharedPreferences prefs = mPrefs;
             Log.i(TAG, "loadSettings");
             mSettingsValues = RunInLocaleKt.runInLocale(context, locale,
-                    ctx -> new SettingsValues(ctx, prefs, ctx.getResources(), inputAttributes));
+                    ctx -> new SettingsValues(ctx, prefs, ctx.getResources(), inputAttributes, currentKeyboardScript));
         } finally {
             mSettingsValuesLock.unlock();
         }

--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -48,6 +48,7 @@ public class SettingsValues {
         public final long mDoubleSpacePeriodTimeout;
         // From configuration:
         public final Locale mLocale;
+        public final String mCurrentKeyboardScript;
         public final boolean mHasHardwareKeyboard;
         public final int mDisplayOrientation;
         // From preferences
@@ -172,8 +173,9 @@ public class SettingsValues {
         // creation of Colors and SpacingAndPunctuations are the slowest parts in here,
         // but still ok
         public SettingsValues(final Context context, final SharedPreferences prefs, final Resources res,
-                        @NonNull final InputAttributes inputAttributes) {
+                        @NonNull final InputAttributes inputAttributes, final String currentKeyboardScript) {
                 mLocale = ConfigurationCompatKt.locale(res.getConfiguration());
+                mCurrentKeyboardScript = currentKeyboardScript;
                 mDisplayOrientation = res.getConfiguration().orientation;
                 final InputMethodSubtype selectedSubtype = SubtypeSettings.INSTANCE.getSelectedSubtype(prefs);
 
@@ -518,6 +520,8 @@ public class SettingsValues {
                 sb.append("" + mKeyLongpressTimeout);
                 sb.append("\n   mLocale = ");
                 sb.append("" + mLocale);
+                sb.append("\n   mCurrentKeyboardScript = ");
+                sb.append("" + mCurrentKeyboardScript);
                 sb.append("\n   mInputAttributes = ");
                 sb.append("" + mInputAttributes);
                 sb.append("\n   mKeypressVibrationDuration = ");

--- a/app/src/main/java/helium314/keyboard/latin/spellcheck/AndroidSpellCheckerService.java
+++ b/app/src/main/java/helium314/keyboard/latin/spellcheck/AndroidSpellCheckerService.java
@@ -31,6 +31,7 @@ import helium314.keyboard.latin.settings.Defaults;
 import helium314.keyboard.latin.settings.Settings;
 import helium314.keyboard.latin.settings.SettingsValuesForSuggestion;
 import helium314.keyboard.latin.utils.KtxKt;
+import helium314.keyboard.latin.utils.ScriptUtils;
 import helium314.keyboard.latin.utils.SubtypeSettings;
 import helium314.keyboard.latin.utils.SubtypeUtilsAdditional;
 import helium314.keyboard.latin.utils.SuggestionResults;
@@ -202,7 +203,7 @@ public final class AndroidSpellCheckerService extends SpellCheckerService
             // but creating a global one if not existing should be fine too
             final EditorInfo editorInfo = new EditorInfo();
             editorInfo.inputType = InputType.TYPE_CLASS_TEXT;
-            Settings.getInstance().loadSettings(this, locale, new InputAttributes(editorInfo, false, getPackageName()));
+            Settings.getInstance().loadSettings(this, locale, new InputAttributes(editorInfo, false, getPackageName()), ScriptUtils.SCRIPT_UNKNOWN);
         }
         final String mainLayoutName = SubtypeSettings.INSTANCE.getMatchingMainLayoutNameForLocale(locale);
         final InputMethodSubtype subtype = SubtypeUtilsAdditional.INSTANCE.createDummyAdditionalSubtype(locale, mainLayoutName);

--- a/app/src/main/java/helium314/keyboard/settings/SettingsActivity.kt
+++ b/app/src/main/java/helium314/keyboard/settings/SettingsActivity.kt
@@ -68,7 +68,7 @@ open class SettingsActivity : ComponentActivity(), SharedPreferences.OnSharedPre
         super.onCreate(savedInstanceState)
         if (Settings.getValues() == null) {
             val inputAttributes = InputAttributes(EditorInfo(), false, packageName)
-            Settings.getInstance().loadSettings(this, resources.configuration.locale(), inputAttributes)
+            Settings.getInstance().loadSettings(this, resources.configuration.locale(), inputAttributes, helium314.keyboard.latin.utils.ScriptUtils.SCRIPT_UNKNOWN)
         }
         ExecutorUtils.getBackgroundExecutor(ExecutorUtils.KEYBOARD).execute { cleanUnusedMainDicts(this) }
         crashReportFiles.value = findCrashReports(!BuildConfig.DEBUG && !DebugFlags.DEBUG_ENABLED)


### PR DESCRIPTION
The refactoring successfully moves the `currentKeyboardScript` argument from several methods in `InputLogic.java` into the `SettingsValues` class, addressing a TODO and reducing redundancy in the codebase. All call sites have been updated and compilation has been verified.

---
*PR created automatically by Jules for task [1215721178354382085](https://jules.google.com/task/1215721178354382085) started by @LeanBitLab*