### PR TITLE
Fix: show all symbols in letter long-press popup (#113)

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/KeyboardParser.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/KeyboardParser.kt
@@ -267,7 +267,13 @@ class KeyboardParser(private val params: KeyboardParams, private val context: Co
         if (!params.mId.mNumberRowEnabled && params.mId.mNumberRowInSymbols && params.mId.mElementId == KeyboardId.ELEMENT_SYMBOLS) {
             // replace first symbols row with number row, but use the labels as popupKeys
             val numberRowCopy = numberRow.toMutableList()
-            numberRowCopy.forEachIndexed { index, keyData -> keyData.popup.symbol = baseKeys[0].getOrNull(index)?.label }
+            numberRowCopy.forEachIndexed { index, keyData ->
+                val symbolKey = baseKeys[0].getOrNull(index) ?: return@forEachIndexed
+                val symbols = mutableListOf<String>()
+                symbolKey.label.takeIf { it.isNotEmpty() }?.let { symbols.add(it) }
+                symbolKey.popup.getPopupKeyLabels(params)?.let { symbols.addAll(it) }
+                if (symbols.isNotEmpty()) keyData.popup.symbols = symbols
+            }
             baseKeys[0] = numberRowCopy
         } else if (!params.mId.mNumberRowEnabled && params.mId.isAlphabetKeyboard && !hasBuiltInNumbers()) {
             if (baseKeys[0].any { it.popup.main != null || !it.popup.relevant.isNullOrEmpty() } // first row of baseKeys has any layout popup key
@@ -290,7 +296,11 @@ class KeyboardParser(private val params: KeyboardParams, private val context: Co
         layout.forEachIndexed { i, row ->
             val baseRow = baseKeys.getOrNull(i) ?: return@forEachIndexed
             row.forEachIndexed { j, key ->
-                baseRow.getOrNull(j)?.popup?.symbol = key.label
+                val baseKey = baseRow.getOrNull(j) ?: return@forEachIndexed
+                val symbols = mutableListOf<String>()
+                key.label.takeIf { it.isNotEmpty() }?.let { symbols.add(it) }
+                key.popup.getPopupKeyLabels(params)?.let { symbols.addAll(it) }
+                if (symbols.isNotEmpty()) baseKey.popup.symbols = symbols
             }
         }
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/PopupSet.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/PopupSet.kt
@@ -28,7 +28,7 @@ open class PopupSet<T : AbstractKeyData>(
     open fun isEmpty(): Boolean = main == null && relevant.isNullOrEmpty()
 
     var numberLabel: String? = null
-    var symbol: String? = null // maybe list of keys?
+    var symbols: Collection<String>? = null
 
     fun <U : AbstractKeyData> merge(other: PopupSet<U>?): PopupSet<out AbstractKeyData> {
         if (other == null || other.isEmpty()) return this

--- a/app/src/main/java/helium314/keyboard/latin/utils/PopupKeysUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/PopupKeysUtils.kt
@@ -31,7 +31,7 @@ fun createPopupKeysArray(popupSet: PopupSet<*>?, params: KeyboardParams, label: 
         when (type) {
             POPUP_KEYS_NUMBER -> popupSet?.numberLabel?.let { popupKeys.add(it) }
             POPUP_KEYS_LAYOUT -> popupSet?.getPopupKeyLabels(params)?.let { popupKeys.addAll(it) }
-            POPUP_KEYS_SYMBOLS -> popupSet?.symbol?.let { popupKeys.add(it) }
+            POPUP_KEYS_SYMBOLS -> popupSet?.symbols?.let { popupKeys.addAll(it) }
             POPUP_KEYS_LANGUAGE -> params.mLocaleKeyboardInfos.getPopupKeys(label)?.let { popupKeys.addAll(it) }
             POPUP_KEYS_LANGUAGE_PRIORITY -> params.mLocaleKeyboardInfos.getPriorityPopupKeys(label)?.let { popupKeys.addAll(it) }
         }
@@ -66,7 +66,7 @@ fun getHintLabel(popupSet: PopupSet<*>?, params: KeyboardParams, label: String):
         when (type) {
             POPUP_KEYS_NUMBER -> popupSet?.numberLabel?.let { hintLabel = it }
             POPUP_KEYS_LAYOUT -> popupSet?.getPopupKeyLabels(params)?.let { hintLabel = it.firstOrNull() }
-            POPUP_KEYS_SYMBOLS -> popupSet?.symbol?.let { hintLabel = it }
+            POPUP_KEYS_SYMBOLS -> popupSet?.symbols?.let { hintLabel = it.firstOrNull() }
             POPUP_KEYS_LANGUAGE -> params.mLocaleKeyboardInfos.getPopupKeys(label)?.let { hintLabel = it.firstOrNull() }
             POPUP_KEYS_LANGUAGE_PRIORITY -> params.mLocaleKeyboardInfos.getPriorityPopupKeys(label)?.let { hintLabel = it.firstOrNull() }
         }


### PR DESCRIPTION
## Summary

When long-pressing a letter, the popup includes a `symbol` taken from the corresponding position of the symbols layout. Previously only the symbol key's primary label was propagated; the symbol key's own popups were silently dropped. So a symbols-layout entry like `% ‰` (where `%` is the key and `‰` is its popup) would only contribute `%` to the letter's popup.

This PR makes the letter popup include both the symbol key's label and all of its popup labels.

## Changes

- `PopupSet.symbol: String?` → `PopupSet.symbols: Collection<String>?` (the existing `// maybe list of keys?` TODO comment hinted at this).
- `KeyboardParser.addSymbolPopupKeys` (and the number-row-in-symbols branch of `addNumberRowOrPopupKeys`) now collect `key.label` plus `key.popup.getPopupKeyLabels(params)`.
- `PopupKeysUtils.createPopupKeysArray` uses `addAll(symbols)`; `getHintLabel` keeps a single hint via `firstOrNull()`.

The change is local to the symbols-popup pipeline and doesn't touch any other popup source (number / layout / language / language priority).

## Test

- `./gradlew :app:compileStandardDebugKotlin` succeeds.
- `./gradlew :app:testStandardDebugUnitTest`: the 9 failures present are the same ones present on `main` before this patch (unrelated — `LayoutUtils.getContent` cannot find layout assets in the test classpath, plus a couple of pre-existing emoji/input-logic failures). No new regressions.
- Manually verified by reading the symbols layout file: e.g. `q` (row 0, col 0) now offers `%` and `‰`; `f` (row 1, col 3) offers `_`, `%`, `‰`; `b` (row 2, col 5) offers `-`, `–`, `⁻`, `—`, `·`.

## Disclosure

This patch was AI-assisted: investigation and code changes were produced with GitHub Copilot CLI. I reviewed the diff before opening the PR.

Fixes #113
