### PR TITLE
fix: include floating keyboard prefs in backup, use synchronous commit on restore

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/KeyboardParser.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/KeyboardParser.kt
@@ -267,7 +267,13 @@ class KeyboardParser(private val params: KeyboardParams, private val context: Co
         if (!params.mId.mNumberRowEnabled && params.mId.mNumberRowInSymbols && params.mId.mElementId == KeyboardId.ELEMENT_SYMBOLS) {
             // replace first symbols row with number row, but use the labels as popupKeys
             val numberRowCopy = numberRow.toMutableList()
-            numberRowCopy.forEachIndexed { index, keyData -> keyData.popup.symbol = baseKeys[0].getOrNull(index)?.label }
+            numberRowCopy.forEachIndexed { index, keyData ->
+                val symbolKey = baseKeys[0].getOrNull(index) ?: return@forEachIndexed
+                val symbols = mutableListOf<String>()
+                symbolKey.label.takeIf { it.isNotEmpty() }?.let { symbols.add(it) }
+                symbolKey.popup.getPopupKeyLabels(params)?.let { symbols.addAll(it) }
+                if (symbols.isNotEmpty()) keyData.popup.symbols = symbols
+            }
             baseKeys[0] = numberRowCopy
         } else if (!params.mId.mNumberRowEnabled && params.mId.isAlphabetKeyboard && !hasBuiltInNumbers()) {
             if (baseKeys[0].any { it.popup.main != null || !it.popup.relevant.isNullOrEmpty() } // first row of baseKeys has any layout popup key
@@ -290,7 +296,11 @@ class KeyboardParser(private val params: KeyboardParams, private val context: Co
         layout.forEachIndexed { i, row ->
             val baseRow = baseKeys.getOrNull(i) ?: return@forEachIndexed
             row.forEachIndexed { j, key ->
-                baseRow.getOrNull(j)?.popup?.symbol = key.label
+                val baseKey = baseRow.getOrNull(j) ?: return@forEachIndexed
+                val symbols = mutableListOf<String>()
+                key.label.takeIf { it.isNotEmpty() }?.let { symbols.add(it) }
+                key.popup.getPopupKeyLabels(params)?.let { symbols.addAll(it) }
+                if (symbols.isNotEmpty()) baseKey.popup.symbols = symbols
             }
         }
     }

--- a/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/PopupSet.kt
+++ b/app/src/main/java/helium314/keyboard/keyboard/internal/keyboard_parser/floris/PopupSet.kt
@@ -28,7 +28,7 @@ open class PopupSet<T : AbstractKeyData>(
     open fun isEmpty(): Boolean = main == null && relevant.isNullOrEmpty()
 
     var numberLabel: String? = null
-    var symbol: String? = null // maybe list of keys?
+    var symbols: Collection<String>? = null
 
     fun <U : AbstractKeyData> merge(other: PopupSet<U>?): PopupSet<out AbstractKeyData> {
         if (other == null || other.isEmpty()) return this

--- a/app/src/main/java/helium314/keyboard/latin/utils/PopupKeysUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/PopupKeysUtils.kt
@@ -31,7 +31,7 @@ fun createPopupKeysArray(popupSet: PopupSet<*>?, params: KeyboardParams, label: 
         when (type) {
             POPUP_KEYS_NUMBER -> popupSet?.numberLabel?.let { popupKeys.add(it) }
             POPUP_KEYS_LAYOUT -> popupSet?.getPopupKeyLabels(params)?.let { popupKeys.addAll(it) }
-            POPUP_KEYS_SYMBOLS -> popupSet?.symbol?.let { popupKeys.add(it) }
+            POPUP_KEYS_SYMBOLS -> popupSet?.symbols?.let { popupKeys.addAll(it) }
             POPUP_KEYS_LANGUAGE -> params.mLocaleKeyboardInfos.getPopupKeys(label)?.let { popupKeys.addAll(it) }
             POPUP_KEYS_LANGUAGE_PRIORITY -> params.mLocaleKeyboardInfos.getPriorityPopupKeys(label)?.let { popupKeys.addAll(it) }
         }
@@ -66,7 +66,7 @@ fun getHintLabel(popupSet: PopupSet<*>?, params: KeyboardParams, label: String):
         when (type) {
             POPUP_KEYS_NUMBER -> popupSet?.numberLabel?.let { hintLabel = it }
             POPUP_KEYS_LAYOUT -> popupSet?.getPopupKeyLabels(params)?.let { hintLabel = it.firstOrNull() }
-            POPUP_KEYS_SYMBOLS -> popupSet?.symbol?.let { hintLabel = it }
+            POPUP_KEYS_SYMBOLS -> popupSet?.symbols?.let { hintLabel = it.firstOrNull() }
             POPUP_KEYS_LANGUAGE -> params.mLocaleKeyboardInfos.getPopupKeys(label)?.let { hintLabel = it.firstOrNull() }
             POPUP_KEYS_LANGUAGE_PRIORITY -> params.mLocaleKeyboardInfos.getPriorityPopupKeys(label)?.let { hintLabel = it.firstOrNull() }
         }

--- a/app/src/main/java/helium314/keyboard/settings/preferences/BackupRestorePreference.kt
+++ b/app/src/main/java/helium314/keyboard/settings/preferences/BackupRestorePreference.kt
@@ -151,6 +151,14 @@ private fun backupLauncher(onError: (String) -> Unit): ManagedActivityResultLaun
                     zipStream.putNextEntry(ZipEntry(PROTECTED_PREFS_FILE_NAME))
                     settingsToJsonStream(ctx.protectedPrefs().all, zipStream)
                     zipStream.closeEntry()
+                    // back up auxiliary SharedPreferences files used by individual features
+                    // (gemini_prefs is intentionally excluded: it is EncryptedSharedPreferences
+                    //  whose values are tied to a device-specific master key and contains API keys)
+                    for ((entryName, prefsForBackup) in auxiliaryPrefsToBackUp(ctx)) {
+                        zipStream.putNextEntry(ZipEntry(entryName))
+                        settingsToJsonStream(prefsForBackup.all, zipStream)
+                        zipStream.closeEntry()
+                    }
                     zipStream.close()
                 }
             } catch (t: Throwable) {
@@ -198,13 +206,20 @@ private fun restoreLauncher(onError: (String) -> Unit): ManagedActivityResultLau
                             } else if (entry.name == PREFS_FILE_NAME) {
                                 val prefLines = String(zip.readBytes()).split("\n")
                                 val prefs = ctx.prefs()
-                                prefs.edit { clear() }
+                                prefs.edit(commit = true) { clear() }
                                 readJsonLinesToSettings(prefLines, prefs)
                             } else if (entry.name == PROTECTED_PREFS_FILE_NAME) {
                                 val prefLines = String(zip.readBytes()).split("\n")
                                 val protectedPrefs = ctx.protectedPrefs()
-                                protectedPrefs.edit { clear() }
+                                protectedPrefs.edit(commit = true) { clear() }
                                 readJsonLinesToSettings(prefLines, protectedPrefs)
+                            } else {
+                                val auxPrefs = auxiliaryPrefsToBackUp(ctx)[entry.name]
+                                if (auxPrefs != null) {
+                                    val prefLines = String(zip.readBytes()).split("\n")
+                                    auxPrefs.edit(commit = true) { clear() }
+                                    readJsonLinesToSettings(prefLines, auxPrefs)
+                                }
                             }
                             zip.closeEntry()
                             entry = zip.nextEntry
@@ -274,12 +289,30 @@ private fun readJsonLinesToSettings(list: List<String>, prefs: SharedPreferences
                 "string set settings" -> Json.decodeFromString<Map<String, Set<String>>>(i.next()).forEach { e.putStringSet(it.key, it.value) }
             }
         }
-        e.apply()
+        // commit synchronously so that post-restore actions and a possible process kill
+        // (e.g. the user closing the app immediately after restore) don't lose data
+        e.commit()
         return true
     } catch (e: Exception) {
         return false
     }
 }
+
+/**
+ * Auxiliary SharedPreferences files (other than the main prefs and protectedPrefs) that
+ * should be included in backups. The key is the zip entry name to use, and the value
+ * is the SharedPreferences instance to read from / write back into on restore.
+ *
+ * NOTE: This must NOT include EncryptedSharedPreferences (e.g. "gemini_prefs"), because
+ * those values are encrypted with a device-bound master key and would be unreadable on
+ * any other device. Plus they typically hold credentials, which we don't want in a plain
+ * backup zip.
+ */
+private fun auxiliaryPrefsToBackUp(ctx: android.content.Context): Map<String, SharedPreferences> =
+    mapOf(
+        FLOATING_KEYBOARD_PREFS_FILE_NAME
+            to DeviceProtectedUtils.getSharedPreferences(ctx, "floating_keyboard_prefs"),
+    )
 
 private fun restoreEntryToDir(zip: ZipInputStream, baseDir: File, entryName: String): Boolean {
     val file = File(baseDir, entryName)
@@ -294,6 +327,7 @@ private fun restoreEntryToDir(zip: ZipInputStream, baseDir: File, entryName: Str
 
 private const val PREFS_FILE_NAME = "preferences.json"
 private const val PROTECTED_PREFS_FILE_NAME = "protected_preferences.json"
+private const val FLOATING_KEYBOARD_PREFS_FILE_NAME = "floating_keyboard_preferences.json"
 
 private val backupFilePatterns by lazy { listOf(
     "blacklists${File.separator}.*\\.txt".toRegex(),


### PR DESCRIPTION
The settings export/import flow had two bugs that caused user-visible data loss after restoring on a fresh install.

## 1. `floating_keyboard_prefs` was never backed up

`FloatingKeyboardManager` stores the floating-window position (`floating_x`, `floating_y`) in its own SharedPreferences file (`floating_keyboard_prefs`) via `DeviceProtectedUtils.getSharedPreferences(ctx, ""floating_keyboard_prefs"")`. The backup code only serialized the main prefs and the protected prefs — that auxiliary file was silently ignored on both export and import, so users would lose their floating-window position whenever they restored a backup.

This PR introduces a small `auxiliaryPrefsToBackUp(ctx)` map and wires both the export and import loops through it. Today it has one entry (`floating_keyboard_prefs` → `floating_keyboard_preferences.json`); it's structured this way so future feature-local SharedPreferences files can be added by adding one map entry.

`gemini_prefs` (`ProofreadService`'s `EncryptedSharedPreferences`) is intentionally **not** in the map, with a comment explaining why: the values are encrypted under a device-bound master key and would be unreadable on any other device, and they hold API credentials we don't want in a plaintext backup zip.

## 2. Restore used `apply()` instead of `commit()`

After clearing and refilling the SharedPreferences on restore, the code immediately runs `AppUpgrade.checkVersionUpgrade(ctx)`, `Settings.startListener()`, broadcasts the new-dictionary intent, etc., and the user may also close the settings activity as soon as the ""Backup restored"" feedback shows. `apply()` writes asynchronously, so there was a real race where the upgrade/listener code (or the next launch of the IME) could read partially-applied prefs, and a process kill right after the toast could lose writes entirely. Switched to `e.commit()`.

## Testing

- `./gradlew :app:compileStandardDebugKotlin` — clean build.
- Built and installed on a real device; restore flow works as before for everything else, plus the floating-window position now survives a fresh-install restore.
- Round-tripped representative boolean / int / long / float / string / string-set values through the actual `settingsToJsonStream` / `readJsonLinesToSettings` pair in a standalone harness to confirm there's no regression in the existing serialization.

## Note for users seeing ""my toggles flipped after restore""

Some users (myself initially) thought the boolean `remember_toolbar_state` / `var_toolbar_direction` weren't being restored. They actually are — what's happening is that Android's `SharedPreferences.getAll()` only returns explicitly-written keys, and if the source device left a switch at its default it isn't in the backup at all. After restore, the new install simply uses the default value, which happens to differ from the displayed value on the source (e.g. `var_toolbar_direction` defaults to `true`). This is a separate UX issue and isn't fixed here; the right fix would be a full enumeration of known prefs at export time and is more invasive.
