### PR TITLE
fix(proofread): Validate pastKeyValues against model inputs

### DIFF
--- a/app/src/offline/java/helium314/keyboard/latin/utils/ProofreadService.kt
+++ b/app/src/offline/java/helium314/keyboard/latin/utils/ProofreadService.kt
@@ -480,7 +480,7 @@ class ProofreadService(private val context: Context) {
                 }
 
                 // CRITICAL FIX: Only use valid pastKeyValues if model actually accepts PKV inputs
-                val inputTokens = if (step > 0 && isValidPkv) {
+                val inputTokens = if (step > 0 && isValidPkv && hasPkvInputs) {
                     longArrayOf(generatedTokens.last())
                 } else {
                     generatedTokens.toLongArray()


### PR DESCRIPTION
Added `hasPkvInputs` validation in `ProofreadService.kt` to ensure `pastKeyValues` are only used if the model actually accepts them.

---
*PR created automatically by Jules for task [10907207899037206775](https://jules.google.com/task/10907207899037206775) started by @LeanBitLab*