### PR TITLE
fix(settings): always show language switch key when toggle is on

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/SettingsValues.java
@@ -460,13 +460,10 @@ public class SettingsValues {
                 if (!mShowsLanguageSwitchKey) {
                         return false;
                 }
+                // The behavior preference (mLanguageSwitchKeyToOtherImes / mLanguageSwitchKeyToOtherSubtypes)
+                // only controls what tapping the key does — it must not gate visibility, otherwise the
+                // toggle silently has no effect for users with a single enabled subtype (the common case).
                 final RichInputMethodManager imm = RichInputMethodManager.getInstance();
-                if (!mLanguageSwitchKeyToOtherSubtypes) {
-                        return imm.hasMultipleEnabledIMEsOrSubtypes(false /* include aux subtypes */);
-                }
-                if (!mLanguageSwitchKeyToOtherImes) {
-                        return imm.hasMultipleEnabledSubtypesInThisIme(false /* include aux subtypes */);
-                }
                 return imm.hasMultipleEnabledSubtypesInThisIme(false /* include aux subtypes */)
                                 || imm.hasMultipleEnabledIMEsOrSubtypes(false /* include aux subtypes */);
         }


### PR DESCRIPTION
## Summary
Make the "Language switch key" toggle actually show the key in the common
case (single enabled subtype). Closes https://github.com/LeanBitLab/LeanType/issues/143

## Problem
`SettingsValues#isLanguageSwitchKeyEnabled()` used the *behavior* preference
(`PREF_LANGUAGE_SWITCH_KEY`: `internal` / `input_method` / `both`) to decide
*visibility*. With the default `internal` behavior, the key is hidden
whenever the user has only one subtype enabled in this IME — i.e. for a
typical freshly-installed user. Turning the toggle on appears to do nothing.

## Fix
Removed the behavior-based branches. The key is now shown whenever:
1. the user has the toggle on, AND
2. there is anywhere to switch to (any other subtype in this IME OR any
   other enabled IME).

The behavior preference still fully controls tap action — see
`LatinIME#switchToNextSubtype()` and `RichInputMethodManager#canSwitchLanguage()`,
both untouched. No regression for users who configured a specific behavior.

## Verification
- `isLanguageSwitchKeyEnabled()` returns `true` whenever the toggle is on
  and there is something to switch to. With nothing to switch to (single
  IME, single subtype), it still returns `false` (avoids a useless key).
- Single-file change; no public API, resources, or other call sites touched.

## Note on upstream
The same code path exists in upstream `Helium314/HeliBoard`. I verified by
reading the source, not by running their build. Happy to forward this
upstream after it lands here if the maintainers prefer.