### PR TITLE
Enable HTTP OpenAI endpoints for local self hosted models

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@ SPDX-License-Identifier: Apache-2.0 AND GPL-3.0-only
             android:allowBackup="false"
             android:defaultToDeviceProtectedStorage="true"
             android:directBootAware="true"
+            android:usesCleartextTraffic="true"
             tools:remove="android:appComponentFactory"
             tools:targetApi="p">
 


### PR DESCRIPTION
Currently fails when trying to set an HTTP endpoint