### PR TITLE
fix(layout): change default popup key on letter ا in Persian language

### DIFF
--- a/app/src/main/assets/locale_key_texts/fa.txt
+++ b/app/src/main/assets/locale_key_texts/fa.txt
@@ -1,7 +1,7 @@
 [popup_keys]
 ه ﻫ|ه‍ هٔ ة
 ی ئ ي ﯨ|ى
-ا !fixedOrder!5 ٱ ء آ أ إ
+ا !fixedOrder!5 آ ء ٱ أ إ
 ت ة
 ک ك
 و ؤ


### PR DESCRIPTION
The former default popup key is mostly used in arabic. This PR changes the default popup key to the letter that is commonly used in persian. I've done the exact same PR for heliboard in https://github.com/HeliBorg/HeliBoard/pull/2541

Resolves #181 
