### PR TITLE
Fix sticky Shift when handwriting view is hidden

### DIFF
--- a/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
+++ b/app/src/main/java/helium314/keyboard/keyboard/KeyboardSwitcher.java
@@ -361,8 +361,10 @@ public final class KeyboardSwitcher implements KeyboardState.SwitchActions {
         mClipboardHistoryView.setVisibility(View.GONE);
         mClipboardHistoryView.stopClipboardHistory();
         if (mHandwritingView != null) {
+            if (mHandwritingView.isShown()) {
+                mHandwritingView.stopHandwriting();
+            }
             mHandwritingView.setVisibility(View.GONE);
-            mHandwritingView.stopHandwriting();
         }
         
         if (PointerTracker.sPersistentTouchpadModeActive) {


### PR DESCRIPTION
## Summary

Fixes #186.

The v3.8.6 handwriting integration stops the handwriting view on every main-keyboard frame switch:

```java
mHandwritingView.setVisibility(View.GONE);
mHandwritingView.stopHandwriting();
```

`stopHandwriting()` closes the handwriting bottom-row keyboard (`bottomRowKeyboard.closing()`), which calls `MainKeyboardView.cancelAllOngoingEvents()` and globally cancels active `PointerTracker`s. When the user taps Shift, the keyboard switches to the manual-shift layout while the Shift pointer is still down; the unconditional handwriting cleanup cancels that Shift pointer before its ACTION_UP is delivered. The Shift state remains PRESSING/CHORDING, so typing stays uppercase until the keyboard is reset.

Only stop the handwriting view when it is actually shown. If it is already hidden, just keep it hidden without closing its bottom-row keyboard / cancelling global pointer trackers.

## Verification

- Reproduced on the downstream merged debug build with diagnostic logs: Shift press reached `KeyboardState`, then `PointerTrackerQueue.cancelAllPointerTrackers()` cancelled the Shift pointer before release; subsequent letters arrived with Shift in CHORDING state.
- Applied this exact one-line guard in the downstream merge branch and installed the debug build; Shift now returns to lowercase after the first typed letter.
- `./gradlew.bat compileStandardRunTestsKotlin --no-daemon --console=plain` passes on this upstream-based branch (with `ANDROID_HOME=C:\Android\Sdk`).