### PR TITLE
fix: number row keeps digits when keyboard is shifted to uppercase

### DIFF
--- a/app/src/main/assets/layouts/number_row/number_row.json
+++ b/app/src/main/assets/layouts/number_row/number_row.json
@@ -1,44 +1,14 @@
 [
     [
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": "!" },
-        "default": { "label": "1", "popup": { "relevant": [{ "label": "¹" }, { "label": "½" }, { "label": "⅓" }, { "label": "¼" }, { "label": "⅛" }] } }
-      },
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": "@" },
-        "default": { "label": "2", "popup": { "relevant": [{ "label": "²" }, { "label": "⅔" }] } }
-      },
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": "#" },
-        "default": { "label": "3", "popup": { "relevant": [{ "label": "³" }, { "label": "¾" }, { "label": "⅜" }] } }
-      },
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": "$" },
-        "default": { "label": "4", "popup": { "relevant": [{ "label": "⁴" }] } }
-      },
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": "%" },
-        "default": { "label": "5", "popup": { "relevant": [{ "label": "⁵" }, { "label": "⅝" }] } }
-      },
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": "^" },
-        "default": { "label": "6", "popup": { "relevant": [{ "label": "⁶" }] } }
-      },
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": "&" },
-        "default": { "label": "7", "popup": { "relevant": [{ "label": "⁷" }, { "label": "⅞" }] } }
-      },
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": "*" },
-        "default": { "label": "8", "popup": { "relevant": [{ "label": "⁸" }] } }
-      },
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": "(" },
-        "default": { "label": "9", "popup": { "relevant": [{ "label": "⁹" }] } }
-      },
-      { "$": "shift_state_selector",
-        "manualOrLocked": { "label": ")" },
-        "default": { "label": "0", "popup": { "relevant": [{ "label": "⁰" }, { "label": "ⁿ" }, { "label": "∅" }] } }
-      }
+        { "label": "1", "popup": { "relevant": [{ "label": "!" }, { "label": "¹" }, { "label": "½" }, { "label": "⅓" }, { "label": "¼" }, { "label": "⅛" }] } },
+        { "label": "2", "popup": { "relevant": [{ "label": "@" }, { "label": "²" }, { "label": "⅔" }] } },
+        { "label": "3", "popup": { "relevant": [{ "label": "#" }, { "label": "³" }, { "label": "¾" }, { "label": "⅜" }] } },
+        { "label": "4", "popup": { "relevant": [{ "label": "$" }, { "label": "⁴" }] } },
+        { "label": "5", "popup": { "relevant": [{ "label": "%" }, { "label": "⁵" }, { "label": "⅝" }] } },
+        { "label": "6", "popup": { "relevant": [{ "label": "^" }, { "label": "⁶" }] } },
+        { "label": "7", "popup": { "relevant": [{ "label": "&" }, { "label": "⁷" }, { "label": "⅞" }] } },
+        { "label": "8", "popup": { "relevant": [{ "label": "*" }, { "label": "⁸" }] } },
+        { "label": "9", "popup": { "relevant": [{ "label": "(" }, { "label": "⁹" }] } },
+        { "label": "0", "popup": { "relevant": [{ "label": ")" }, { "label": "⁰" }, { "label": "ⁿ" }, { "label": "∅" }] } }
     ]
-  ]
+]

--- a/app/src/test/java/helium314/keyboard/KeyboardParserTest.kt
+++ b/app/src/test/java/helium314/keyboard/KeyboardParserTest.kt
@@ -284,6 +284,29 @@ f""", // no newline at the end
     }]]""", Expected('.'.code, ".", popups = listOf(">").map { it to it.first().code }))
     }
 
+    @Test fun numberRowKeepsDigitsWhenShifted() {
+        val numberRowKey = """[[{ "label": "1", "popup": {
+        "relevant": [
+          { "label": "!" },
+          { "label": "¹" },
+          { "label": "½" },
+          { "label": "⅓" },
+          { "label": "¼" },
+          { "label": "⅛" }
+        ]
+      } }]]"""
+        val expected = Expected('1'.code, "1", popups = listOf("!", "¹", "½", "⅓", "¼", "⅛").map { it to it.first().code })
+        listOf(
+            KeyboardId.ELEMENT_ALPHABET,
+            KeyboardId.ELEMENT_ALPHABET_MANUAL_SHIFTED,
+            KeyboardId.ELEMENT_ALPHABET_SHIFT_LOCKED,
+            KeyboardId.ELEMENT_ALPHABET_SHIFT_LOCK_SHIFTED
+        ).forEach { elementId ->
+            params.mId = KeyboardLayoutSet.getFakeKeyboardId(elementId)
+            assertIsExpected(numberRowKey, expected)
+        }
+    }
+
     @Test fun nestedSelectors() {
         assertIsExpected("""[[{ "$": "shift_state_selector",
       "shiftedManual": { "code":   34, "label": "\"", "popup": {


### PR DESCRIPTION
## Summary

Keeps the number row showing `1234567890` in every shift state instead of swapping the digits for `!@#$%^&*()` when the keyboard is shifted or shift-locked. The shifted symbols stay reachable as long-press popups, ahead of the existing fraction/superscript popups.

## Why this matters

`assets/layouts/number_row/number_row.json` defined each top-row key as a `shift_state_selector` whose `manualOrLocked` branch rendered the shifted symbol (`!`, `@`, `#`, ...) while only the `default` branch rendered the digit. `ShiftStateSelector.compute` resolves to `manualOrLocked` for `ELEMENT_ALPHABET_MANUAL_SHIFTED`, `ELEMENT_ALPHABET_SHIFT_LOCKED`, and `ELEMENT_ALPHABET_SHIFT_LOCK_SHIFTED`, so engaging shift replaced the visible digits with symbols. The number row is meant to stay numeric regardless of shift (matching `number_row_basic.txt`).

The failing case fixed: with the number row enabled, pressing shift (or shift-lock) no longer turns `1234567890` into `!@#$%^&*()`. Each key is now a plain digit key whose popup keeps the shifted symbol as the first entry, so nothing is lost.

A regression test (`numberRowKeepsDigitsWhenShifted` in `KeyboardParserTest`) parses a number-row key and asserts the digit label and its popups across the unshifted, manual-shifted, and shift-locked keyboard element IDs.

Fixes #180
