### PR TITLE
feat: add toggle to disable long-press hint dots on toolbar keys

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Defaults.kt
@@ -184,6 +184,7 @@ object Defaults {
     const val PREF_TOOLBAR_MODE = "EXPANDABLE"
     const val PREF_TOOLBAR_HIDING_GLOBAL = true
     const val PREF_QUICK_PIN_TOOLBAR_KEYS = true
+    const val PREF_TOOLBAR_LONG_PRESS_HINT = true
     val PREF_PINNED_TOOLBAR_KEYS = defaultPinnedToolbarPref
     val PREF_TOOLBAR_KEYS = defaultToolbarPref
     const val PREF_AUTO_SHOW_TOOLBAR = false

--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -189,6 +189,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String PREF_URL_DETECTION = "url_detection";
     public static final String PREF_DONT_SHOW_MISSING_DICTIONARY_DIALOG = "dont_show_missing_dict_dialog";
     public static final String PREF_QUICK_PIN_TOOLBAR_KEYS = "quick_pin_toolbar_keys";
+    public static final String PREF_TOOLBAR_LONG_PRESS_HINT = "toolbar_long_press_hint";
     public static final String PREF_DISABLE_NETWORK = "disable_network";
     public static final String PREF_PINNED_TOOLBAR_KEYS = "pinned_toolbar_keys";
     public static final String PREF_TOOLBAR_KEYS = "toolbar_keys";

--- a/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
+++ b/app/src/main/java/helium314/keyboard/latin/utils/ToolbarUtils.kt
@@ -80,7 +80,11 @@ fun createToolbarKey(context: Context, key: ToolbarKey): ImageButton {
         KeyboardIconsSet.instance.getNewDrawable(key.name, context)
     }
 
-    val finalDrawable = if (rawDrawable != null && getCodeForToolbarKeyLongClick(key) != KeyCode.UNSPECIFIED) {
+    val showLongPressHint = context.prefs()
+        .getBoolean(Settings.PREF_TOOLBAR_LONG_PRESS_HINT, Defaults.PREF_TOOLBAR_LONG_PRESS_HINT)
+    val finalDrawable = if (rawDrawable != null && showLongPressHint
+        && getCodeForToolbarKeyLongClick(key) != KeyCode.UNSPECIFIED
+    ) {
         LongPressHintDrawable(rawDrawable)
     } else {
         rawDrawable

--- a/app/src/main/java/helium314/keyboard/settings/screens/ToolbarScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/ToolbarScreen.kt
@@ -76,6 +76,7 @@ fun ToolbarScreen(
         if (!isSplitToolbar) Settings.PREF_PINNED_TOOLBAR_KEYS else null,
         Settings.PREF_CLIPBOARD_TOOLBAR_KEYS,
         Settings.PREF_TOOLBAR_CUSTOM_KEY_CODES,
+        Settings.PREF_TOOLBAR_LONG_PRESS_HINT,
         if (toolbarMode == ToolbarMode.EXPANDABLE && !isSplitToolbar) Settings.PREF_QUICK_PIN_TOOLBAR_KEYS else null,
         if (toolbarMode == ToolbarMode.EXPANDABLE && !isSplitToolbar) Settings.PREF_AUTO_SHOW_TOOLBAR else null,
         if (toolbarMode == ToolbarMode.EXPANDABLE && !isSplitToolbar) Settings.PREF_AUTO_SHOW_TOOLBAR_ON_SELECT else null,
@@ -144,6 +145,11 @@ fun createToolbarSettings(context: Context): List<Setting> {
             R.string.quick_pin_toolbar_keys, R.string.quick_pin_toolbar_keys_summary)
         {
             SwitchPreference(it, Defaults.PREF_QUICK_PIN_TOOLBAR_KEYS) { KeyboardSwitcher.getInstance().setThemeNeedsReload() }
+        },
+        Setting(context, Settings.PREF_TOOLBAR_LONG_PRESS_HINT,
+            R.string.toolbar_long_press_hint, R.string.toolbar_long_press_hint_summary)
+        {
+            SwitchPreference(it, Defaults.PREF_TOOLBAR_LONG_PRESS_HINT) { KeyboardSwitcher.getInstance().setThemeNeedsReload() }
         },
         Setting(context, Settings.PREF_AUTO_SHOW_TOOLBAR, R.string.auto_show_toolbar_open, R.string.auto_show_toolbar_summary)
         {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -629,6 +629,10 @@
     <string name="quick_pin_toolbar_keys">Pin toolbar key on long press</string>
     <!-- Description of the setting to quick-pin toolbar keys -->
     <string name="quick_pin_toolbar_keys_summary">This will disable other long press actions for toolbar keys that are not pinned</string>
+    <!-- Title of the setting to show long-press hint dots on toolbar keys -->
+    <string name="toolbar_long_press_hint">Show long-press hint dots</string>
+    <!-- Description of the setting to show long-press hint dots on toolbar keys -->
+    <string name="toolbar_long_press_hint_summary">Show dots on toolbar keys that have a long-press action</string>
     <!-- Title of the setting to show "..." as hints for more functionality on long-press -->
     <string name="show_popup_hints">Show functional hints</string>
     <!-- Description of the show_popup_hints setting -->


### PR DESCRIPTION
## Summary

Adds a toolbar setting to disable the long-press hint dots shown on toolbar keys. The hints stay on by default, so existing behavior is unchanged; users who find the dots distracting can now turn them off.

## Why this matters

Issue #218 asks for a way to hide the small long-press indicator dots on the toolbar keys. There was no setting for it, so users who did not want the visual clutter had no option. This adds a boolean preference (defaulting to the current behavior), surfaces it in the Toolbar settings screen, and reads it where the toolbar keys are rendered so the dots are drawn only when the preference is enabled.

## Changes

- New preference key + default in `Settings`/`Defaults` (default keeps hints visible).
- Toggle row added to the Toolbar settings screen with a matching string resource.
- `ToolbarUtils` reads the preference and omits the long-press hint dots when disabled.

## Testing

Change is limited to a new opt-in preference and its read site; default rendering is unchanged. Verified by code inspection that the preference is wired through defaults, the settings UI, and the toolbar rendering path. On-device build was not exercised in this environment.

Fixes #218
