### PR TITLE
fix(clipboard): null-safe keyboard icon access and input-view race guard in suggestion callbacks

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
+++ b/app/src/main/java/helium314/keyboard/latin/ClipboardHistoryManager.kt
@@ -83,6 +83,10 @@ class ClipboardHistoryManager(
                     super.onChange(selfChange, uri)
                     if (latinIME.mSettings.current.mSuggestScreenshots) {
                         updateLatestScreenshotCache {
+                            // Race guard (field NPE 22 Aug 2026): a screenshot can land before the
+                            // keyboard view exists — getSuggestionStripView() must not run on a
+                            // half-built IME. Skip; the next input show will surface the suggestion.
+                            if (!latinIME.isInputViewShown) return@updateLatestScreenshotCache
                             latinIME.tryShowClipboardSuggestion()
                         }
                     }
@@ -553,8 +557,8 @@ class ClipboardHistoryManager(
         latinIME.mSettings.getCustomTypeface()?.let { textView.typeface = it }
         textView.text = (if (isClipSensitive(inputType)) "*".repeat(content.length) else content)
             .take(200) // truncate displayed text for performance reasons
-        val clipIcon = latinIME.mKeyboardSwitcher.keyboard.mIconsSet.getIconDrawable(ToolbarKey.PASTE.name.lowercase())
-        textView.setCompoundDrawablesRelativeWithIntrinsicBounds(clipIcon, null, null, null)
+        val clipIcon = activeKeyboardIcons()?.getIconDrawable(ToolbarKey.PASTE.name.lowercase())
+        clipIcon?.let { textView.setCompoundDrawablesRelativeWithIntrinsicBounds(it, null, null, null) }
         textView.setOnClickListener {
             dontShowCurrentSuggestion = true
             latinIME.onTextInput(content.toString())
@@ -562,7 +566,9 @@ class ClipboardHistoryManager(
             binding.root.isGone = true
         }
         val closeButton = binding.clipboardSuggestionClose
-        closeButton.setImageDrawable(latinIME.mKeyboardSwitcher.keyboard.mIconsSet.getIconDrawable(ToolbarKey.CLOSE_HISTORY.name.lowercase()))
+        activeKeyboardIcons()?.getIconDrawable(ToolbarKey.CLOSE_HISTORY.name.lowercase())?.let { closeIcon ->
+            closeButton.setImageDrawable(closeIcon)
+        }
         closeButton.setOnClickListener {
             val prefs = latinIME.prefs()
             prefs.edit().putString("last_dismissed_clipboard_text", content.toString()).apply()
@@ -580,6 +586,19 @@ class ClipboardHistoryManager(
     }
 
     private var lastSuggestedScreenshotUri: String? = null
+
+    /** Safe access to the active keyboard's icon set. The keyboard view is built lazily and torn
+     *  down with input views, so a spontaneous clipboard/screenshot callback can run while it does
+     *  not exist (field NPE 22 Aug 2026: Keyboard.mIconsSet read on null reference). Returns null
+     *  instead of crashing; callers degrade to an icon-less suggestion. */
+    private fun activeKeyboardIcons(): helium314.keyboard.keyboard.internal.KeyboardIconsSet? {
+        return try {
+            val kb = latinIME.mKeyboardSwitcher.keyboard ?: return null
+            kb.mIconsSet
+        } catch (e: Exception) {
+            null
+        }
+    }
 
     private fun getScreenshotSuggestionView(parent: ViewGroup?): View? {
         if (parent == null || dontShowCurrentSuggestion) return null
@@ -642,8 +661,9 @@ class ClipboardHistoryManager(
                 val drawable = android.graphics.drawable.BitmapDrawable(latinIME.resources, croppedThumb)
                 textView.setCompoundDrawablesRelativeWithIntrinsicBounds(drawable, null, null, null)
             } catch (e: Exception) {
-                val clipIcon = latinIME.mKeyboardSwitcher.keyboard.mIconsSet.getIconDrawable(ToolbarKey.PASTE.name.lowercase())
-                textView.setCompoundDrawablesRelativeWithIntrinsicBounds(clipIcon, null, null, null)
+                activeKeyboardIcons()?.getIconDrawable(ToolbarKey.PASTE.name.lowercase())?.let { clipIcon ->
+                    textView.setCompoundDrawablesRelativeWithIntrinsicBounds(clipIcon, null, null, null)
+                }
             }
         }
 
@@ -656,7 +676,9 @@ class ClipboardHistoryManager(
         }
         
         val closeButton = binding.clipboardSuggestionClose
-        closeButton.setImageDrawable(latinIME.mKeyboardSwitcher.keyboard.mIconsSet.getIconDrawable(ToolbarKey.CLOSE_HISTORY.name.lowercase()))
+        activeKeyboardIcons()?.getIconDrawable(ToolbarKey.CLOSE_HISTORY.name.lowercase())?.let { closeIcon ->
+            closeButton.setImageDrawable(closeIcon)
+        }
         closeButton.setOnClickListener { 
             val prefs = latinIME.prefs()
             val rawDeletedSet = prefs.getStringSet("deleted_screenshot_uris", emptySet()) ?: emptySet()


### PR DESCRIPTION
## Bug Description

The IME process dies when a screenshot lands while the keyboard view does not exist. Observed three times in one day on a Pixel-era Samsung (S24+, Android 16) running the debug build:

```
java.lang.NullPointerException: Attempt to read from field
'helium314.keyboard.keyboard.internal.KeyboardIconsSet helium314.keyboard.keyboard.Keyboard.mIconsSet'
on a null object reference in method
'android.view.View helium314.keyboard.latin.ClipboardHistoryManager.getScreenshotSuggestionView(android.view.ViewGroup)'
  at ClipboardHistoryManager.getScreenshotSuggestionView(ClipboardHistoryManager.kt:659)
  at ClipboardHistoryManager.getClipboardSuggestionView(ClipboardHistoryManager.kt:526)
  at LatinIME.tryShowClipboardSuggestion(LatinIME.java:2038)
  at ClipboardHistoryManager$registerScreenshotObserver$1.onChange$lambda$0(ClipboardHistoryManager.kt:86)
```

The MediaStore ContentObserver fires as soon as any screenshot appears system-wide, even while the IME service is idle with no input view inflated.

## Root Cause

Two independent problems combine:

1. `getScreenshotSuggestionView()` / `getClipboardSuggestionView()` read `latinIME.mKeyboardSwitcher.keyboard.mIconsSet` unguarded. `mKeyboardSwitcher.keyboard` is null whenever no keyboard view is currently built, so any callback racing view construction/teardown NPEs on the main thread.
2. The screenshot observer's `onChange` calls `updateLatestScreenshotCache { latinIME.tryShowClipboardSuggestion() }` without checking that an input view exists, guaranteeing that race is reachable in normal use.

## Fix

- New private helper `activeKeyboardIcons()`: null-safe access to the active keyboard's icon set (`KeyboardIconsSet?`). All four icon call sites now degrade gracefully - the suggestion renders icon-less instead of crashing.
- Screenshot observer skips `tryShowClipboardSuggestion()` while `isInputViewShown` is false. Nothing is lost: the next input-view show re-runs clipboard/screenshot suggestion logic through the normal path.

No behaviour change when the keyboard view exists (the overwhelmingly common case) - icons resolve exactly as before.

## How to Verify

1. Build and install, enable "Suggest screenshots".
2. With the keyboard dismissed, take a screenshot from another app (e.g. via quick settings while no editable field is focused).
3. Before this PR: IME process crashes (`FATAL EXCEPTION: main`, NPE at `getScreenshotSuggestionView`). After: no crash; opening an editable field still shows the screenshot suggestion normally.
4. Regression check: keyboard visible + take a screenshot -> suggestion strip shows the screenshot chip with paste/close icons as usual.

## Test Plan

- [ ] No new unit test (crash path involves Android view lifecycle; verified manually on device)
- [x] `:app:compileStandardDebugKotlin` passes on the PR branch
- [x] Manual verification on device (Samsung Galaxy S24+, Android 16) - previously-crashing sequence now clean

## Risk Assessment

Low - strictly defensive changes: null-guards that fall back to not drawing two toolbar icons in a transient state, plus skipping a speculative UI refresh that the next input-show repeats anyway. No change to commit paths, gesture handling, or prediction.